### PR TITLE
Fix error de ESLint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,6 +10,12 @@ module.exports = {
   ignorePatterns: ['dist', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',
   plugins: ['react-refresh'],
+  overrides: [
+    {
+      files: ['*.ts', '*.tsx'],
+      parserOptions: { project: ['./tsconfig.json'] },
+    },
+  ],
   rules: {
     'prettier/prettier': 'warn',
     '@typescript-eslint/no-unused-vars': 'warn',


### PR DESCRIPTION
Faltaba la config **parserOptions.project** para que funcione ESLint con los plugins agregados.