### PR TITLE
Fix "UploadImage" bug (On Console) with browserRoute on /verify-certificate

### DIFF
--- a/src/components/uploadImage/index.tsx
+++ b/src/components/uploadImage/index.tsx
@@ -51,7 +51,7 @@ export function UploadImage({
       try {
         navigate(paths.verifyCertificate);
       } catch (error) {
-        toast.error('Hubo un error al navegar a la página de verificación', {
+        toast.error('Hubo un error al cargar la página porfavor refresqué la misma.', {
           icon: '⛔',
         });
       }

--- a/src/components/uploadImage/index.tsx
+++ b/src/components/uploadImage/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import ImageInput from '#/components/imageInput';
 import { getBase64 } from '#/utils';
 import Button from '#/components/button';
@@ -41,12 +41,15 @@ export function UploadImage({
     setPreview(undefined);
     setUploaded(false);
   };
-
-  if (uploaded) {
-    navigate(paths.verifyCertificate);
-    return null; // Puedes retornar null o cualquier otro contenido que desees en este caso
-  }
-
+  /* No estoy totalmente seguro de qué esto sea optimo, 
+  pero el useEffect se activa cuando uploaded cambia, 
+  lo que solo va a ocurrir una vez,
+  después de que el usuario ha subido una imagen */
+  useEffect(() => {
+    if (uploaded) {
+      navigate(paths.verifyCertificate);
+    }
+  }, [uploaded, navigate]);
   return (
     <div className="flex flex-col items-center text-lg">
       <div

--- a/src/components/uploadImage/index.tsx
+++ b/src/components/uploadImage/index.tsx
@@ -4,6 +4,7 @@ import { getBase64 } from '#/utils';
 import Button from '#/components/button';
 import { Link, useNavigate } from 'react-router-dom';
 import { paths } from '#/routes/paths';
+ import toast, { Toaster } from 'react-hot-toast';
 
 const CheckItem = ({ text }: { text: string }) => (
   <div className="flex justify-space-around items-center md:text-xl text-sm gap-2 h-12">
@@ -47,7 +48,13 @@ export function UploadImage({
   después de que el usuario ha subido una imagen */
   useEffect(() => {
     if (uploaded) {
-      navigate(paths.verifyCertificate);
+      try {
+        navigate(paths.verifyCertificate);
+      } catch (error) {
+        toast.error('Hubo un error al navegar a la página de verificación', {
+          icon: '⛔',
+        });
+      }
     }
   }, [uploaded, navigate]);
   return (
@@ -96,6 +103,7 @@ export function UploadImage({
             handleOnChange={(ev) => onUploadInternal(ev.target.files?.[0])}
           />
           <p className="mx-auto">Tomar foto</p>
+          <Toaster position="top-right" reverseOrder={false} />
         </label>
       </div>
     </div>


### PR DESCRIPTION
Si o si el navigate necesitaba colocarlo en un useEffect, y el buen chatGPT no lo pudo explicar mejor:  
  useEffect permite diferir la navegación hasta después 
  de que el componente UploadImage se ha renderizado por 
  completo. Al utilizar useEffect con [uploaded, navigate] 
  como dependencias, aseguras que la llamada a navigate se ejecute cuando uploaded cambia.