### PR TITLE
Certificate inputs states styles

### DIFF
--- a/src/components/button/index.tsx
+++ b/src/components/button/index.tsx
@@ -14,6 +14,8 @@ export default function Button({
     filled: 'bg-violet-brand text-white',
     outlined: 'border border-violet-brand text-violet-brand',
     ghost: 'text-violet-brand',
+    disabled: 'text-text-off bg-gray-disabled cursor-default',
+    error: 'bg-red text-white',
   };
 
   const buttonAppereance = appereances[appearance];

--- a/src/components/button/types.ts
+++ b/src/components/button/types.ts
@@ -1,4 +1,9 @@
-export type ButtonAppearance = 'filled' | 'outlined' | 'ghost';
+export type ButtonAppearance =
+  | 'filled'
+  | 'outlined'
+  | 'ghost'
+  | 'disabled'
+  | 'error';
 
 export interface IButtonProps {
   children?: React.ReactNode;

--- a/src/pages/load-information/loadInformation.tsx
+++ b/src/pages/load-information/loadInformation.tsx
@@ -438,9 +438,9 @@ const LoadInformationPage: FC<ILoadInformationProps> = () => {
                     </div>
                     <div
                       className="cursor-pointer"
-                      onClick={() =>
-                        setFieldValue('correctData', !values.correctData)
-                      }
+                      onClick={() => {
+                        setFieldValue('correctData', !values.correctData);
+                      }}
                     >
                       <h3 className="text-left text-sm tracking-tight">
                         Verifico que controlé y que todos los datos son
@@ -467,9 +467,11 @@ const LoadInformationPage: FC<ILoadInformationProps> = () => {
                               : 'button',
                           )
                         }
-                        className="bg-gray-300 p-[14px] text-black rounded-xl font-light text-[1.125rem] tracking-wider w-full cursor-default"
+                        className="p-[14px]  rounded-xl font-light text-[1.125rem] tracking-wider w-full"
                         type="button"
                         label="Enviar datos"
+                        disabled
+                        appearance="disabled"
                       />
                       <Toaster position="top-right" reverseOrder={false} />
                     </div>
@@ -481,9 +483,10 @@ const LoadInformationPage: FC<ILoadInformationProps> = () => {
                     <Link to={paths.sendSuccess} className="w-full">
                       <Button
                         onClick={() => onSubmit(values)}
-                        className="bg-violet-primary p-[14px] text-white rounded-xl font-light text-[1.125rem] tracking-wider w-full"
+                        className="p-[14px] rounded-xl font-light text-[1.125rem] tracking-wider w-full"
                         type="submit"
                         label="Enviar datos"
+                        appearance="filled"
                       />
                       <Toaster position="top-right" reverseOrder={false} />
                     </Link>
@@ -492,9 +495,12 @@ const LoadInformationPage: FC<ILoadInformationProps> = () => {
                     <Link to={paths.sendSuccess} className="w-full">
                       <Button
                         onClick={() => onSubmit(values)}
-                        className="bg-red p-[14px] text-white rounded-xl font-light text-[1.125rem] tracking-wider w-full"
+                        className="p-[14px] rounded-xl font-light text-[1.125rem] tracking-wider w-full"
                         type="submit"
                         label="Enviar datos"
+                        appearance="error"
+                        // Seteo disabled hasta que este el feat del modal.
+                        disabled
                       />
                       <Toaster position="top-right" reverseOrder={false} />
                     </Link>

--- a/src/pages/load-information/loadInformation.tsx
+++ b/src/pages/load-information/loadInformation.tsx
@@ -438,9 +438,9 @@ const LoadInformationPage: FC<ILoadInformationProps> = () => {
                     </div>
                     <div
                       className="cursor-pointer"
-                      onClick={() => {
-                        setFieldValue('correctData', !values.correctData);
-                      }}
+                      onClick={() =>
+                        setFieldValue('correctData', !values.correctData)
+                      }
                     >
                       <h3 className="text-left text-sm tracking-tight">
                         Verifico que controlé y que todos los datos son

--- a/src/pages/verify-certificate/verifyCertificate.tsx
+++ b/src/pages/verify-certificate/verifyCertificate.tsx
@@ -102,9 +102,11 @@ const VerifyCertificate = () => {
             {!correctData ? (
               <div className="flex w-full justify-center">
                 <Button
-                  className="w-full p-3 text-[18px] font-light tracking-wider text-text-off bg-gray-300 rounded-xl max-w-sm cursor-default"
+                  className="w-full p-3 text-[18px] font-light tracking-wider rounded-xl max-w-sm"
                   type="button"
                   label="Continuar"
+                  disabled
+                  appearance="disabled"
                 />
               </div>
             ) : (
@@ -118,11 +120,12 @@ const VerifyCertificate = () => {
             )}
             <Link to={paths.uploadCertificate} className="flex w-full justify-center">
               <Button
-                className="w-full p-3 text-[18px] font-light tracking-wider border-2 border-violet-brand text-violet-brand hover:border-violet-light mt-4 rounded-xl max-w-sm"
+                className="w-full p-3 text-[18px] font-light tracking-wider border-2 hover:border-violet-light mt-4 rounded-xl max-w-sm"
                 type="submit"
                 label="Volver a cargar imagen"
                 disabled={imageUploaded}
                 onClick={handleReset}
+                appearance="outlined"
               />
             </Link>
           </div>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,6 +18,7 @@ export default {
         'gray-darker': '#413B50',
         'gray-inactive': '#CACACB',
         'gray-light': '#CBD5E1',
+        'gray-disabled': '#E3E3E9',
         'text-off': '#363F45',
         red: '#AD3459',
         'red-error': '#E13C3C',


### PR DESCRIPTION
+ Se modifican los estilos de los estados de los botones en /verify-certificate y /load-information

![image](https://github.com/LlibertadApp/frontend/assets/91202214/4347e8ce-b231-4f40-a32c-bd02f5f250f6)
![image](https://github.com/LlibertadApp/frontend/assets/91202214/d06acc82-d9d5-49e8-a57f-4ffa67010656)
![image](https://github.com/LlibertadApp/frontend/assets/91202214/2076cd39-d47f-4c2a-99fa-b5f24548b40c)
![image](https://github.com/LlibertadApp/frontend/assets/91202214/7028e931-3c64-4f10-b0c0-79557d7dc869)
![image](https://github.com/LlibertadApp/frontend/assets/91202214/b60f5f9a-167d-4eec-9ad9-c601aba928a6)
