### PR TITLE
Fix Background Figure responsiveness

### DIFF
--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -57,8 +57,8 @@ const LoginPage: React.FC = () => {
 
   return user ? (
     <>
-      <div className="lg:absolute lg:inset-0 lg:bg-[radial-gradient(ellipse_at_bottom_right,_var(--tw-gradient-stops))] from-white to-violet-primary lg:z-0"></div>
-      <main className="px-4 mt-52 mx-auto flex flex-col items-center max-w-md lg:max-w-[624px] lg:px-[108px] lg:py-[50px] rounded-3xl lg:relative lg:bg-white">
+      <div className="lg:fixed lg:inset-0 lg:bg-[radial-gradient(ellipse_at_bottom_right,_var(--tw-gradient-stops))] from-white to-violet-primary lg:z-0" />
+      <main className="px-4 mt-[50px] mx-auto flex flex-col items-center max-w-md lg:max-w-[624px] lg:px-[108px] lg:py-[50px] rounded-3xl lg:relative lg:bg-white">
         <img
           src="assets/logos/fenix-new-bg.svg"
           alt="fenix"


### PR DESCRIPTION
Ahora cubre a toda la pantalla y está fixed al usuario cuando scrollea:
![image](https://github.com/LlibertadApp/frontend/assets/90626121/fa952064-f6e1-42ee-900e-6ae87fe0cd2a)
